### PR TITLE
DEVOPS-3041 adding basic entitlement types and functions

### DIFF
--- a/internal/config/entitlements.go
+++ b/internal/config/entitlements.go
@@ -1,0 +1,20 @@
+package config
+
+// implements the authorization EntitlementGetter interface
+func (c *Config) GetEntitlements(boundaries ...string) []Entitlement {
+	es := []Entitlement{}
+
+	used := make(map[string]int)
+
+	for _, g := range boundaries {
+		if vanityNames, ok := c.Entitlements[g]; ok {
+			for _, v := range vanityNames {
+				if _, ok := used[string(v)]; !ok {
+					es = append(es, c.VanityDistrbutions[string(v)])
+					used[string(v)] = 1
+				}
+			}
+		}
+	}
+	return es
+}

--- a/internal/config/entitlements.go
+++ b/internal/config/entitlements.go
@@ -1,7 +1,7 @@
 package config
 
 // implements the authorization EntitlementGetter interface
-func (c *Config) GetEntitlements(boundaries ...string) []Entitlement {
+func (c *Config) GetEntitlements(distrbution string, boundaries ...string) []Entitlement {
 	es := []Entitlement{}
 
 	used := make(map[string]int)
@@ -9,9 +9,11 @@ func (c *Config) GetEntitlements(boundaries ...string) []Entitlement {
 	for _, g := range boundaries {
 		if vanityNames, ok := c.Entitlements[g]; ok {
 			for _, v := range vanityNames {
-				if _, ok := used[string(v)]; !ok {
-					es = append(es, c.VanityDistrbutions[string(v)])
-					used[string(v)] = 1
+				if string(v) == distrbution {
+					if _, ok := used[string(v)]; !ok {
+						es = append(es, c.VanityDistrbutions[v])
+						used[string(v)] = 1
+					}
 				}
 			}
 		}

--- a/internal/config/entitlements_test.go
+++ b/internal/config/entitlements_test.go
@@ -27,51 +27,56 @@ func TestGetEntitlements(t *testing.T) {
 				Prefix:         "/",
 			},
 			"vn2": Entitlement{
-				DistributionID: "d1",
+				DistributionID: "d2",
 				Prefix:         "/",
 			},
 		},
 	}
 
 	tests := []struct {
-		boundaries []string
-		want       []Entitlement
+		distribution string
+		boundaries   []string
+		want         []Entitlement
 	}{
 		{
-			boundaries: []string{"grp1", "grp2"},
-			want: []Entitlement{
-				c.VanityDistrbutions["vn1"],
-				c.VanityDistrbutions["vn2"],
-			},
-		},
-		{
-			boundaries: []string{"grp2"},
+			distribution: "vn1",
+			boundaries:   []string{"grp1", "grp2"},
 			want: []Entitlement{
 				c.VanityDistrbutions["vn1"],
 			},
 		},
 		{
-			boundaries: []string{"grp1"},
+			distribution: "vn1",
+			boundaries:   []string{"grp2"},
 			want: []Entitlement{
 				c.VanityDistrbutions["vn1"],
+			},
+		},
+
+		{
+			distribution: "vn1",
+			boundaries:   []string{"grp1"},
+			want: []Entitlement{
+				c.VanityDistrbutions["vn1"],
+			},
+		},
+
+		{
+			distribution: "vn2",
+			boundaries:   []string{"grp3"},
+			want: []Entitlement{
 				c.VanityDistrbutions["vn2"],
 			},
 		},
 
 		{
-			boundaries: []string{"grp3"},
-			want: []Entitlement{
-				c.VanityDistrbutions["vn2"],
-			},
-		},
-
-		{
-			boundaries: []string{"not-exists"},
-			want:       []Entitlement{},
+			distribution: "vn2",
+			boundaries:   []string{"not-exists"},
+			want:         []Entitlement{},
 		},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, c.GetEntitlements(test.boundaries...), test.want)
+		assert.Equal(t, test.want, c.GetEntitlements(test.distribution, test.boundaries...))
 	}
 }

--- a/internal/config/entitlements_test.go
+++ b/internal/config/entitlements_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEntitlements(t *testing.T) {
+	c := &Config{
+		Entitlements: map[string][]VanityDistrbutionName{
+			"grp1": {
+				"vn1",
+				"vn2",
+			},
+			"grp2": {
+				"vn1",
+			},
+			"grp3": {
+				"vn2",
+			},
+		},
+
+		VanityDistrbutions: VanityDistrbution{
+			"vn1": Entitlement{
+				DistributionID: "d1",
+				Prefix:         "/",
+			},
+			"vn2": Entitlement{
+				DistributionID: "d1",
+				Prefix:         "/",
+			},
+		},
+	}
+
+	tests := []struct {
+		boundaries []string
+		want       []Entitlement
+	}{
+		{
+			boundaries: []string{"grp1", "grp2"},
+			want: []Entitlement{
+				c.VanityDistrbutions["vn1"],
+				c.VanityDistrbutions["vn2"],
+			},
+		},
+		{
+			boundaries: []string{"grp2"},
+			want: []Entitlement{
+				c.VanityDistrbutions["vn1"],
+			},
+		},
+		{
+			boundaries: []string{"grp1"},
+			want: []Entitlement{
+				c.VanityDistrbutions["vn1"],
+				c.VanityDistrbutions["vn2"],
+			},
+		},
+
+		{
+			boundaries: []string{"grp3"},
+			want: []Entitlement{
+				c.VanityDistrbutions["vn2"],
+			},
+		},
+
+		{
+			boundaries: []string{"not-exists"},
+			want:       []Entitlement{},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, c.GetEntitlements(test.boundaries...), test.want)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,0 +1,15 @@
+package config
+
+type Entitlement struct {
+	DistributionID string `json:"distributionId"`
+	Prefix         string `json:"prefix"`
+}
+
+type VanityDistrbution map[string]Entitlement
+
+type VanityDistrbutionName string
+
+type Config struct {
+	Entitlements       map[string][]VanityDistrbutionName
+	VanityDistrbutions VanityDistrbution
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,7 +5,7 @@ type Entitlement struct {
 	Prefix         string `json:"prefix"`
 }
 
-type VanityDistrbution map[string]Entitlement
+type VanityDistrbution map[VanityDistrbutionName]Entitlement
 
 type VanityDistrbutionName string
 


### PR DESCRIPTION
In order to properly create an authorization middleware, this PR is adding the base config types and a `GetEntitlements` function that will satisfy an interface within the authorization middleware. 


The GetEntitlements function will accept the vanity distribution  (e.g. /api/v1/`<distbrution>`/)  and sboundaries slice and will return the entitlement.  The authorization middleware will take over from there.  The purpose of this function / interface is to abstract as much of the internal config management and types away from the http handlers.