### PR TITLE
Configuration handler WIP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0
+	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -631,3 +631,5 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"sigs.k8s.io/yaml"
+)
+
+type Config struct {
+	Distributions distributions `json:"distributions"`
+	Entitlements entitlements `json:"entitlements"`
+}
+
+func (c *Config) Load(file string) error {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	config := &Config{}
+	if err = yaml.Unmarshal(data, config); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type distributionList = []string
+type entitlements map[string]distributionList
+
+type distributionProperties struct {
+	id string
+	prefix string
+}
+
+type distributions map[string]distributionProperties
+
+type EntitlementManager struct {
+	entitlements entitlements
+	distributions distributions
+}
+
+func NewEntitlementManager(config *Config) *EntitlementManager {
+	return &EntitlementManager{
+		entitlements: config.Entitlements,
+		distributions: config.Distributions,
+	}
+}
+
+
+// TODO This will most likely receive *http.Request instead of "path" in the future
+func (e *EntitlementManager) Entitled(path string, claims []string) bool {
+
+	var distributions []string
+	for _, claim := range claims {
+		if distros, ok := e.entitlements[claim]; ok {
+			distributions = append(distributions, distros...)
+		}
+	}
+
+	for _, distro := range distributions {
+		if distroProps, ok := e.distributions[distro]; ok {
+			if path == distroProps.prefix {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,8 @@ func (c *Config) claimDistributions(claim string) Distributions {
 	return distributions
 }
 
+// claimsDistributions receive a slice of claims and
+// returns a map of distributions
 func (c *Config) claimsDistributions(claims []string) Distributions {
 	allDistributions := make(Distributions)
 
@@ -105,8 +107,7 @@ func (c *Config) claimsDistributions(claims []string) Distributions {
 	return allDistributions
 }
 
-// ClaimsDistributions receive a slice of claims and
-// returns a map of distributions
+// ClaimsDistributions is the public access to claimsDistributions
 func (c *Config) ClaimsDistributions(claims []string) Distributions {
 	return c.claimsDistributions(claims)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,8 +126,14 @@ func (c *Config) ClaimsDistributionNames(claims []string) []string {
 	return names
 }
 
+// ClaimsDistribution gets an specific distribution properties from claims
+// if the distributionName is not present it returns an empty Distribution
 func (c *Config) ClaimsDistribution(claims []string, distributionName string) Distribution {
 	distros := c.claimsDistributions(claims)
 
-	return distros[distributionName]
+	if distro, ok := distros[distributionName]; ok {
+		return distro
+	}
+
+	return Distribution{}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,21 +1,66 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"sort"
+
 	"sigs.k8s.io/yaml"
 )
 
 type distributionName = string
 type claimName = string
-
-type Config struct {
-	Distributions map[distributionName]Distribution `json:"distributions"`
-	Entitlements  map[claimName][]distributionName  `json:"entitlements"`
-}
+type Distributions map[distributionName]Distribution
+type Entitlements map[claimName][]distributionName
 
 type Distribution struct {
 	ID     string `json:"id"`
 	Prefix string `json:"prefix"`
+}
+
+// for marshalling purposes
+type config struct {
+	Distributions Distributions `json:"distributions"`
+	Entitlements  Entitlements  `json:"entitlements"`
+}
+
+type Config struct {
+	distributions Distributions
+	entitlements  Entitlements
+}
+
+// two vanity distributions with the same distribution ID MUST NOT share the same prefix.
+// or in other terms, every pair of id,prefix must be unique
+func (c *Config) validateDistributions() error {
+
+	uniqueMap := make(map[Distribution]struct{})
+
+	for _, value := range c.distributions {
+		if _, ok := uniqueMap[value]; ok {
+			return fmt.Errorf("error parsing configuration: distribution value duplicated id:%s prefix:%s", value.ID, value.Prefix)
+		}
+
+		uniqueMap[value] = struct{}{}
+	}
+
+	return nil
+}
+
+func (c *Config) parse(data []byte) error {
+	config := config{}
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return err
+	}
+
+	c.distributions = config.Distributions
+	c.entitlements = config.Entitlements
+
+	err := c.validateDistributions()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Config) Load(file string) error {
@@ -24,53 +69,65 @@ func (c *Config) Load(file string) error {
 		return err
 	}
 
-	config := &Config{}
-	if err = yaml.Unmarshal(data, config); err != nil {
+	if err := c.parse(data); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-type Entitler interface {
-	Entitled(claims []string) bool
-}
+// claimDistributions receives a claim entitlement and
+// returns a map of distributions
+func (c *Config) claimDistributions(claim string) Distributions {
+	distributions := make(Distributions)
 
-type BaseEntitler struct {
-	distribution string
-	prefix       string
-}
-
-type ConfigEntitler struct {
-	config *Config
-	BaseEntitler
-}
-
-func NewConfigEntitler(config *Config, distribution, prefix string) *ConfigEntitler {
-	return &ConfigEntitler{
-		config: config,
-		BaseEntitler: BaseEntitler{
-			distribution: distribution,
-			prefix:       prefix,
-		},
-	}
-}
-
-func (ce *ConfigEntitler) Entitled(claims []string) bool {
-	for _, claim := range claims {
-		if distros, ok := ce.config.Entitlements[claim]; ok {
-			for _, distro := range distros {
-				if distro == ce.distribution {
-					if distroInfo, ok := ce.config.Distributions[distro]; ok {
-						if distroInfo.Prefix == ce.prefix {
-							return true
-						}
-					}
-
-				}
+	if distros, ok := c.entitlements[claim]; ok {
+		for _, distro := range distros {
+			if _, ok := c.distributions[distro]; ok {
+				distributions[distro] = c.distributions[distro]
 			}
 		}
 	}
 
-	return false
+	return distributions
+}
+
+func (c *Config) claimsDistributions(claims []string) Distributions {
+	allDistributions := make(Distributions)
+
+	for _, claim := range claims {
+		entitlementDistros := c.claimDistributions(claim)
+		for k := range entitlementDistros {
+			allDistributions[k] = entitlementDistros[k]
+		}
+	}
+
+	return allDistributions
+}
+
+// ClaimsDistributions receive a slice of claims and
+// returns a map of distributions
+func (c *Config) ClaimsDistributions(claims []string) Distributions {
+	return c.claimsDistributions(claims)
+}
+
+// ClaimsDistributionNames returns a slice of distribution names
+// after receiving a slice of claims
+func (c *Config) ClaimsDistributionNames(claims []string) []string {
+	distros := c.claimsDistributions(claims)
+
+	names := make([]string, 0, len(distros))
+	for name := range distros {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func (c *Config) ClaimsDistribution(claims []string, distributionName string) Distribution {
+	distros := c.claimsDistributions(claims)
+
+	return distros[distributionName]
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntitled(t *testing.T) {
+	config := Config{
+		Distributions: distributions{
+			"vanity0": {
+				id: "12345",
+				prefix: "/",
+			},
+			"vanity1": {
+				id: "12345",
+				prefix: "/foo",
+			},
+			"vanity3": {
+				id: "4567",
+				prefix: "/bar",
+			},
+		},
+		Entitlements: entitlements{
+			"one": {
+				"vanity1",
+				"vanity2",
+			},
+			"two": {
+				"vanity3",
+			},
+			"three": {
+				"vanity4",
+			},
+		},
+	}
+
+	claims := []string{"one", "two"}
+
+	em := NewEntitlementManager(&config)
+
+	assert.Equal(t, true, em.Entitled("/foo", claims))
+	assert.Equal(t, true, em.Entitled("/bar", claims))
+	assert.Equal(t, false, em.Entitled("/some", claims))
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -166,3 +166,17 @@ func TestClaimsDistributionNames(t *testing.T) {
 		assert.Equal(t, test.want, config.ClaimsDistributionNames(test.claims))
 	}
 }
+
+func TestClaimsDistribution(t *testing.T) {
+	config := setupConfig()
+
+	claims := []string{"grp1"}
+
+	want := Distribution{
+		ID:     "123",
+		Prefix: "/foo",
+	}
+
+	assert.Equal(t, want, config.ClaimsDistribution(claims, "dis1"))
+	assert.Equal(t, Distribution{}, config.ClaimsDistribution(claims, "no-exists"))
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,6 @@ func addRepeatedDistribution(originalDistribution string) configChange {
 }
 
 func setupConfig(changes ...configChange) *Config {
-
 	config := config{
 		Distributions: Distributions{
 			"dis1": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,22 +6,22 @@ import (
 )
 
 func TestEntitled(t *testing.T) {
-	config := Config{
-		Distributions: distributions{
+	config := &Config{
+		Distributions: map[distributionName]Distribution{
 			"vanity0": {
-				id: "12345",
-				prefix: "/",
+				ID: "12345",
+				Prefix: "/",
 			},
 			"vanity1": {
-				id: "12345",
-				prefix: "/foo",
+				ID: "12345",
+				Prefix: "/foo",
 			},
 			"vanity3": {
-				id: "4567",
-				prefix: "/bar",
+				ID: "4567",
+				Prefix: "/bar",
 			},
 		},
-		Entitlements: entitlements{
+		Entitlements: map[claimName][]distributionName{
 			"one": {
 				"vanity1",
 				"vanity2",
@@ -37,9 +37,8 @@ func TestEntitled(t *testing.T) {
 
 	claims := []string{"one", "two"}
 
-	em := NewEntitlementManager(&config)
+	em := NewConfigEntitler(config, "vanity1", "/foo")
 
-	assert.Equal(t, true, em.Entitled("/foo", claims))
-	assert.Equal(t, true, em.Entitled("/bar", claims))
-	assert.Equal(t, false, em.Entitled("/some", claims))
+	assert.Equal(t, true, em.Entitled(claims))
+	assert.Equal(t, true, em.Entitled(claims))
 }


### PR DESCRIPTION
A Config struct is introduced to parse the config file, but how to load that file and reloading is not included so far.

An `Entitler` interface is added to provide a way for the core functionality to call that with claims and check if it's entitled to run invalidations on the prefix specified by the config file.

There's only one object implementing Entitler that is `ConfigEntitler` that receives a config, a distribution and a prefix and use that in `Entitled`. As basic settings like distribution and prefix will be common, I also included a `BaseEntitler` to re-use it if we want to. Please suggest better naming or alternatives on these types.

This PR will only be open in draft mode as is mainly to gather feedback on implementation and code organization.

## Open questions

- How to organize the `Entitler` interface and implementations?
    - in the same config package?
	- in an "entitlement" package or something like that?