### PR TITLE
DEVOPS-3057 adding support for swagger spec doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install --yes ca-certificates
 RUN groupadd -r app && useradd --no-log-init -r -g app app
 USER app
 COPY --from=build /go/bin/app /
+COPY swagger /swagger
 ENV APP_ADDR ":8080"
 EXPOSE 8080
 ENTRYPOINT ["/app"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO_MODULE := $(shell git config --get remote.origin.url | grep -o 'github\.com[:
 CMD_NAME := $(shell basename ${GO_MODULE})
 DEFAULT_APP_PORT ?= 8080
 ENV_VARIABLES := -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN # ENV to pass into container
+SWAGGER := docker run --rm -it -e GOPATH=${GOPATH}:/go -v ${HOME}:${HOME} -w ${PWD} quay.io/goswagger/swagger
 
 RUN ?= .*
 PKG ?= ./...
@@ -36,6 +37,11 @@ docker:
 .PHONY: docker-run
 docker-run: docker ## Build and run the application in a local docker container
 	@docker run -p ${DEFAULT_APP_PORT}:${DEFAULT_APP_PORT} ${ENV_VARIABLES} $(CMD_NAME):latest
+
+
+.PHONY: swagger-gen
+swagger-gen: ## Generate swagger OpenAPI specification
+	$(SWAGGER) generate spec -o ./swagger/swagger.json --scan-models
 
 .PHONY: help
 help:

--- a/internal/core/v1beta1/types.go
+++ b/internal/core/v1beta1/types.go
@@ -14,18 +14,54 @@ type Distribution struct {
 }
 
 type InvalidationMeta struct {
+	// The Status of the invalidation request
 	Status string `json:"status"`
 }
 
+// swagger:model InvalidationResponse
 type InvalidationResponse struct {
 	InvalidationMeta
-	ID      string        `json:"id,omitempty"`
+	// The ID of the Invalidation Request
+	ID string `json:"id,omitempty"`
+
+	// The Created time of invalidation
 	Created time.Duration `json:"createTime"`
-	Paths   []string      `json:"paths,omitempty"`
+
+	// The Paths array requested for invalidation
+	Paths []string `json:"paths,omitempty"`
 }
 
+// swagger:model DistributionResponse
+type DistributionsResponse struct {
+	// The Distributions a user is entitled to perform invalidations against.
+	Distributions map[VanityDistributionName]Distribution `json:"distributions"`
+}
+
+// swagger:model InvalidationRequest
 type InvalidationRequest struct {
+	// The Paths to submit for invalidation
 	Paths []string `json:"paths"`
+}
+
+// swagger:parameters submit-invalidation
+type _ struct {
+	// The Name of the distribution
+	// in:path
+	Name string
+	// The body to create the invalidation
+	// in:body
+	// required: true
+	Body InvalidationRequest
+}
+
+// swagger:parameters get-invalidation
+type _ struct {
+	// The Name of the distribution
+	// in:path
+	Name string
+	// The ID of the invalidation request
+	// in:path
+	ID string
 }
 
 const (
@@ -40,11 +76,15 @@ var (
 	}
 )
 
+// swagger:model InvalidationError
 type InvalidationError struct {
 	InvalidationMeta
 	Err  error `json:"-"`
 	Code int   `json:"-"`
 }
+
+// swagger:model ErrorResponse
+type ErrorResponse string
 
 func (err InvalidationError) Error() string {
 	if err.Err != nil {

--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -25,7 +25,7 @@ func New(router *mux.Router) *mux.Router {
 	return api
 }
 
-// swagger:route GET /api/v1beta/distributions GetDistributions get-distributions
+// swagger:route GET /api/v1beta1/distributions GetDistributions get-distributions
 //
 // Get a list of distributions you are entitled to perform invaildiations
 //
@@ -52,7 +52,7 @@ func getDistributions(ds DistributionService) http.HandlerFunc {
 	}
 }
 
-// swagger:route POST  /api/v1beta/distributions/{name} SubmitInvalidation submit-invalidation
+// swagger:route POST  /api/v1beta1/distributions/{name} SubmitInvalidation submit-invalidation
 //
 // Submit an Invalidation Request
 //
@@ -104,7 +104,7 @@ func createInvalidation(ds DistributionService) http.HandlerFunc {
 	}
 }
 
-// swagger:route GET  /api/v1beta/distributions/{name}/invalidations/{id} InvalidationResponse get-invalidation-status
+// swagger:route GET  /api/v1beta1/distributions/{name}/invalidations/{id} InvalidationResponse get-invalidation-status
 //
 // Get an Invalidation Request
 //

--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -25,7 +25,15 @@ func New(router *mux.Router) *mux.Router {
 	return api
 }
 
-// GET Distributions /api/v1beta/distributions
+// swagger:route GET /api/v1beta/distributions GetDistributions get-distributions
+//
+// Get a list of distributions you are entitled to perform invaildiations
+//
+//
+// responses:
+//   200: DistributionResponse
+//   401: ErrorResponse
+//   500: ErrorResponse
 func getDistributions(ds DistributionService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		d, err := ds.List(r.Context())
@@ -44,7 +52,17 @@ func getDistributions(ds DistributionService) http.HandlerFunc {
 	}
 }
 
-// POST Distributions /api/v1beta/distributions/{name}
+// swagger:route POST  /api/v1beta/distributions/{name} SubmitInvalidation submit-invalidation
+//
+// Submit an Invalidation Request
+//
+//
+// responses:
+//   200: InvalidationResponse
+//   400: InvalidationError
+//   403: ErrorResponse
+//   404: ErrorResponse
+//   500: ErrorResponse
 func createInvalidation(ds DistributionService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -86,7 +104,17 @@ func createInvalidation(ds DistributionService) http.HandlerFunc {
 	}
 }
 
-// GET Invalidation /api/v1beta/distributions/{name}/invalidations/{id}
+// swagger:route GET  /api/v1beta/distributions/{name}/invalidations/{id} InvalidationResponse get-invalidation-status
+//
+// Get an Invalidation Request
+//
+//
+// responses:
+//   200: InvalidationResponse
+//   400: InvalidationError
+//   403: ErrorResponse
+//   404: ErrorResponse
+//   500: ErrorResponse
 func getInvalidation(ds DistributionService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -27,7 +27,7 @@ func New(router *mux.Router) *mux.Router {
 
 // swagger:route GET /api/v1beta1/distributions GetDistributions get-distributions
 //
-// Get a list of distributions you are entitled to perform invaildiations
+// Get a list of distributions you are entitled to perform invalidations
 //
 //
 // responses:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,7 @@ func New(opts ...Option) (http.Handler, error) {
 	s.router.HandleFunc("/", s.handleRoot())
 	s.router.HandleFunc("/healthz", s.handleHealthz())
 	s.router.Handle("/metrics", promhttp.Handler())
+	s.router.PathPrefix("/swagger/").Handler(http.StripPrefix("/swagger", http.FileServer(http.Dir("swagger"))))
 
 	authmiddleware := authorization.New(authorization.WithCookieName(s.authCookieName),
 		authorization.WithAuthorizationHeader())

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1,0 +1,234 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/api/v1beta/distributions": {
+      "get": {
+        "description": "Get a list of distributions you are entitled to perform invaildiations",
+        "tags": [
+          "GetDistributions"
+        ],
+        "operationId": "get-distributions",
+        "responses": {
+          "200": {
+            "description": "DistributionResponse",
+            "schema": {
+              "$ref": "#/definitions/DistributionResponse"
+            }
+          },
+          "401": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1beta/distributions/{name}": {
+      "post": {
+        "description": "Submit an Invalidation Request",
+        "tags": [
+          "SubmitInvalidation"
+        ],
+        "operationId": "submit-invalidation",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The Name of the distribution",
+            "name": "Name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "The body to create the invalidation",
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InvalidationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "InvalidationResponse",
+            "schema": {
+              "$ref": "#/definitions/InvalidationResponse"
+            }
+          },
+          "400": {
+            "description": "InvalidationError",
+            "schema": {
+              "$ref": "#/definitions/InvalidationError"
+            }
+          },
+          "403": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1beta/distributions/{name}/invalidations/{id}": {
+      "get": {
+        "description": "Get an Invalidation Request",
+        "tags": [
+          "InvalidationResponse"
+        ],
+        "operationId": "get-invalidation-status",
+        "responses": {
+          "200": {
+            "description": "InvalidationResponse",
+            "schema": {
+              "$ref": "#/definitions/InvalidationResponse"
+            }
+          },
+          "400": {
+            "description": "InvalidationError",
+            "schema": {
+              "$ref": "#/definitions/InvalidationError"
+            }
+          },
+          "403": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "ErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Distribution": {
+      "type": "object",
+      "properties": {
+        "pathPrefix": {
+          "type": "string",
+          "x-go-name": "PathPrefix"
+        }
+      },
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "DistributionResponse": {
+      "type": "object",
+      "properties": {
+        "distributions": {
+          "description": "The Distributions a user is entitled to perform invalidations against.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Distribution"
+          },
+          "x-go-name": "Distributions"
+        }
+      },
+      "x-go-name": "DistributionsResponse",
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "Duration": {
+      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "time"
+    },
+    "ErrorResponse": {
+      "type": "string",
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "InvalidationError": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "The Status of the invalidation request",
+          "type": "string",
+          "x-go-name": "Status"
+        }
+      },
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "InvalidationMeta": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "The Status of the invalidation request",
+          "type": "string",
+          "x-go-name": "Status"
+        }
+      },
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "InvalidationRequest": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "description": "The Paths to submit for invalidation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Paths"
+        }
+      },
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    },
+    "InvalidationResponse": {
+      "type": "object",
+      "properties": {
+        "createTime": {
+          "$ref": "#/definitions/Duration"
+        },
+        "id": {
+          "description": "The ID of the Invalidation Request",
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "paths": {
+          "description": "The Paths array requested for invalidation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Paths"
+        },
+        "status": {
+          "description": "The Status of the invalidation request",
+          "type": "string",
+          "x-go-name": "Status"
+        }
+      },
+      "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    }
+  }
+}


### PR DESCRIPTION
This is using [go-swagger](https://goswagger.io/install.html) type and route hints to generate swagger.json.

You can view locally by installing and running go-swagger 
```
swagger serve  ./swagger/swagger.json
```

Or by viewing in any SwaggerUI interface.