### PR TITLE
minor bug fix for swagger docs

### DIFF
--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -13,18 +13,6 @@ const ErrUserNotEntitled = "User is not entitled to the CloudFront Invalidation 
 
 const PathPrefix = "/api/v1beta1"
 
-// swagger:meta
-// Perform CDN Invalidations on specific distributions.
-//
-// Scheme: https
-// Security:
-//   - jwt
-// SecurityDefinitions:
-// jwt:
-//   type: Bearer
-//   name: Authorization
-//   in: header
-
 func New(router *mux.Router) *mux.Router {
 	ds := v1beta1.NewFake()
 	api := router.PathPrefix(PathPrefix).Subrouter()

--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -13,6 +13,18 @@ const ErrUserNotEntitled = "User is not entitled to the CloudFront Invalidation 
 
 const PathPrefix = "/api/v1beta1"
 
+// swagger:meta
+// Perform CDN Invalidations on specific distributions.
+//
+// Scheme: https
+// Security:
+//   - jwt
+// SecurityDefinitions:
+// jwt:
+//   type: Bearer
+//   name: Authorization
+//   in: header
+
 func New(router *mux.Router) *mux.Router {
 	ds := v1beta1.NewFake()
 	api := router.PathPrefix(PathPrefix).Subrouter()
@@ -27,8 +39,10 @@ func New(router *mux.Router) *mux.Router {
 
 // swagger:route GET /api/v1beta1/distributions GetDistributions get-distributions
 //
-// Get a list of distributions you are entitled to perform invalidations
+// Get a list of distributions you are entitled to perform invalidations.
 //
+//     Security:
+//       jwt:
 //
 // responses:
 //   200: DistributionResponse
@@ -52,10 +66,12 @@ func getDistributions(ds DistributionService) http.HandlerFunc {
 	}
 }
 
-// swagger:route POST  /api/v1beta1/distributions/{name} SubmitInvalidation submit-invalidation
+// swagger:route POST  /api/v1beta1/distributions/{name}/invalidations SubmitInvalidation submit-invalidation
 //
 // Submit an Invalidation Request
 //
+//     Security:
+//       jwt:
 //
 // responses:
 //   200: InvalidationResponse
@@ -108,6 +124,8 @@ func createInvalidation(ds DistributionService) http.HandlerFunc {
 //
 // Get an Invalidation Request
 //
+//     Security:
+//       jwt:
 //
 // responses:
 //   200: InvalidationResponse

--- a/internal/server/api/v1beta1/doc.go
+++ b/internal/server/api/v1beta1/doc.go
@@ -1,0 +1,14 @@
+// Perform CDN Invalidations on specific distributions.
+//
+// Scheme: https
+// Security:
+//   - jwt
+// SecurityDefinitions:
+// jwt:
+//   type: Bearer
+//   name: Authorization
+//   in: header
+//
+//
+// swagger:meta
+package v1beta1

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1,12 +1,21 @@
 {
   "swagger": "2.0",
+  "info": {
+    "description": "Scheme: https",
+    "title": "Perform CDN Invalidations on specific distributions."
+  },
   "paths": {
     "/api/v1beta1/distributions": {
       "get": {
-        "description": "Get a list of distributions you are entitled to perform invalidations",
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
         "tags": [
           "GetDistributions"
         ],
+        "summary": "Get a list of distributions you are entitled to perform invalidations.",
         "operationId": "get-distributions",
         "responses": {
           "200": {
@@ -30,8 +39,13 @@
         }
       }
     },
-    "/api/v1beta1/distributions/{name}": {
+    "/api/v1beta1/distributions/{name}/invalidations": {
       "post": {
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
         "description": "Submit an Invalidation Request",
         "tags": [
           "SubmitInvalidation"
@@ -91,6 +105,11 @@
     },
     "/api/v1beta1/distributions/{name}/invalidations/{id}": {
       "get": {
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
         "description": "Get an Invalidation Request",
         "tags": [
           "InvalidationResponse"
@@ -229,6 +248,13 @@
         }
       },
       "x-go-package": "github.com/kanopy-platform/cdnvalidator/internal/core/v1beta1"
+    }
+  },
+  "securityDefinitions": {
+    "jwt": {
+      "type": "Bearer",
+      "name": "Authorization",
+      "in": "header"
     }
   }
 }


### PR DESCRIPTION
Minor bug fixes for swagger documentation.    Also included Security definitions for the API endpoints.  As per https://goswagger.io/use/spec/meta.html these are done in the `doc.go` file.