### PR TITLE
Bugfix: show BadRequest Errors

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [push, pull_request]
+      event: [push]
 
   - name: publish-tag
     image: plugins/kaniko-ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
     when:
-      event: [push]
+      event: [push, pull_request]
 
   - name: publish-tag
     image: plugins/kaniko-ecr

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CMD_NAME := $(shell basename ${GO_MODULE})
 DEFAULT_APP_PORT ?= 8080
 DEFAULT_CONFIG_FILE := /config/example_config.yaml
 ENV_VARIABLES := -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN # ENV to pass into container
+LOCAL_REGISTRY := registry.example.com
 SWAGGER := docker run --rm -it -e GOPATH=${GOPATH}:/go -v ${HOME}:${HOME} -w ${PWD} quay.io/goswagger/swagger
 
 RUN ?= .*
@@ -39,6 +40,10 @@ docker:
 docker-run: docker ## Build and run the application in a local docker container
 	@docker run -p ${DEFAULT_APP_PORT}:${DEFAULT_APP_PORT} -v ${PWD}${DEFAULT_CONFIG_FILE}:${DEFAULT_CONFIG_FILE} ${ENV_VARIABLES} $(CMD_NAME):latest --config-file=${DEFAULT_CONFIG_FILE}
 
+.PHONY: docker-push-local
+docker-push-local: ## Build and push the image to local docker registry
+	@docker build -t $(LOCAL_REGISTRY)/$(CMD_NAME):latest .
+	@docker push $(LOCAL_REGISTRY)/$(CMD_NAME):latest
 
 .PHONY: swagger-gen
 swagger-gen: ## Generate swagger OpenAPI specification

--- a/internal/core/v1beta1/types.go
+++ b/internal/core/v1beta1/types.go
@@ -72,6 +72,7 @@ const (
 
 var (
 	statusCodeReasons = map[int]string{
+		BadRequestErrorCode:               "Bad Request: %s",
 		InvalidationUnauthorizedErrorCode: "User is not entitled to invalidate distribution: %s",
 		ResourceNotFoundErrorCode:         "Resource not found: %s",
 	}

--- a/internal/core/v1beta1/types.go
+++ b/internal/core/v1beta1/types.go
@@ -108,6 +108,15 @@ func NewInvalidationError(code int, err error, args ...interface{}) error {
 	}
 }
 
+func ErrorBadRequest(err error) bool {
+	var ierr InvalidationError
+	if !errors.As(err, &ierr) {
+		return false
+	}
+
+	return ierr.Code == BadRequestErrorCode
+}
+
 func ErrorIsUnauthorized(err error) bool {
 	var ierr InvalidationError
 	if !errors.As(err, &ierr) {

--- a/internal/server/api/v1beta1/api.go
+++ b/internal/server/api/v1beta1/api.go
@@ -89,6 +89,11 @@ func createInvalidation(ds DistributionService) http.HandlerFunc {
 
 		status, err := ds.CreateInvalidation(r.Context(), name, invalidationReq.Paths)
 		if err != nil {
+			if v1beta1.ErrorBadRequest(err) {
+				writeJSON(w, err, http.StatusBadRequest)
+				return
+			}
+
 			if v1beta1.ErrorResourceNotFound(err) {
 				writeJSON(w, err, http.StatusNotFound)
 				return


### PR DESCRIPTION
I forgot to add in handlers for `BadRequestErrorCode` errors which results in an unhelpful message `unexpected error`:
```
> curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $USER_TOKEN" https://cdnvalidator.devops.test.corp.mongodb.com/api/v1beta1/distributions/sandbox-infra-test/invalidations -d '{"paths": ["../*", "*"]}'
unexpected error
```

With this change, the error response contains the error
```
> curl -k  -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $USER_TOKEN" https://cdnvalidator.devops.example.com/api/v1beta1/distributions/sandbox-infra-test/invalidations -d '{"paths": ["../*", "*"]}'
{"status":"Bad Request: path cannot contain ../"}
```