### PR TITLE
bugfix: use absolute paths

### DIFF
--- a/internal/core/v1beta1/distribution_service.go
+++ b/internal/core/v1beta1/distribution_service.go
@@ -79,7 +79,7 @@ func (d *DistributionService) CreateInvalidation(ctx context.Context, distributi
 		}
 	}
 	if len(invalidPaths) > 0 {
-		return nil, NewInvalidationError(BadRequestErrorCode, errors.New("unauthorized paths"), invalidPaths)
+		return nil, NewInvalidationError(BadRequestErrorCode, errors.New("unauthorized paths"), fmt.Sprintf("unauthorized paths: %v", invalidPaths))
 	}
 
 	res, err := d.Cloudfront.CreateInvalidation(ctx, distribution.ID, cleanedPaths)

--- a/internal/core/v1beta1/distribution_service_test.go
+++ b/internal/core/v1beta1/distribution_service_test.go
@@ -184,7 +184,7 @@ func TestCreateInvalidation(t *testing.T) {
 			paths:            []string{"/a/*", "/foo/a/b", "/a/../*", "..", "/foo/../*", "/foo/a/..//../*"},
 			mockCf:           &cloudfront.MockCloudFrontClient{},
 			want:             nil,
-			err:              NewInvalidationError(BadRequestErrorCode, errors.New("unauthorized paths"), []string{"/a/*", "/a/../*", "..", "/foo/../*", "/foo/a/..//../*"}),
+			err:              NewInvalidationError(BadRequestErrorCode, errors.New("unauthorized paths"), fmt.Sprintf("unauthorized paths: %v", []string{"/a/*", "/a/../*", "..", "/foo/../*", "/foo/a/..//../*"})),
 		},
 		{
 			// error from cloudfront api


### PR DESCRIPTION
- Use absolute paths
- App will ensure the cleaned paths are valid. Then send to cloudfront the cleaned paths.

### Testing
Tested in minikube cluster against Sandbox CDN.