### PR TITLE
Feature header auth

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ volumes:
 
 steps:
   - name: test
-    image: golangci/golangci-lint:v1.38.0-alpine
+    image: golangci/golangci-lint:v1.53.3
     volumes:
       - name: cache
         path: /go

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
       - name: cache
         path: /go
     commands:
-      - apk add make
+      - go mod download
       - make test
 
   - name: license-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .licenses
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.20 as build
 WORKDIR /go/src/app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /go/bin/app
+RUN CGO_ENABLED=0 go build -o /go/bin/app
 
 FROM debian:buster-slim
 RUN apt-get update && apt-get install --yes ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/app
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install --yes ca-certificates
 RUN groupadd -r app && useradd --no-log-init -r -g app app
 USER app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanopy-platform/cdnvalidator
 
-go 1.16
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.14.0
@@ -17,4 +17,42 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	sigs.k8s.io/yaml v1.3.0
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.11.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.3.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.8.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.10.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.15.0 // indirect
+	github.com/aws/smithy-go v1.11.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("log-level", "info", "Configure log level")
 	cmd.PersistentFlags().String("listen-address", ":8080", "Server listen address")
 	cmd.PersistentFlags().String("auth-cookie", "auth_token", "Auth cookie name")
+	cmd.PersistentFlags().String("auth-header", "", "Header name for the auth token, takes precedence over auth-cookie when set.")
 	cmd.PersistentFlags().String("config-file", "", "Configuration file name")
 	cmd.PersistentFlags().String("aws-region", "us-east-1", "AWS region for Cloudfront")
 	cmd.PersistentFlags().String("aws-key", "", "AWS static credential key for Cloudfront")
@@ -90,6 +91,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		config,
 		cloudfrontClient,
 		server.WithAuthCookieName(viper.GetString("auth-cookie")),
+		server.WithAuthHeaderName(viper.GetString("auth-header")),
 	)
 	if err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -178,7 +177,7 @@ entitlements:
 func TestLoad(t *testing.T) {
 	config := emptyConfig()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "cdnvalidator-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "cdnvalidator-")
 	assert.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 

--- a/internal/server/middleware/authorization/authorization_test.go
+++ b/internal/server/middleware/authorization/authorization_test.go
@@ -74,7 +74,7 @@ func TestAuthorizationResponses(t *testing.T) {
 		{
 			token:      "invalidtoken",
 			middleware: New(),
-			want:       403,
+			want:       401,
 		},
 
 		{

--- a/internal/server/middleware/authorization/options.go
+++ b/internal/server/middleware/authorization/options.go
@@ -8,6 +8,12 @@ func WithCookieName(name string) Option {
 	}
 }
 
+func WithHeaderName(name string) Option {
+	return func(m *middleware) {
+		m.authHeaderName = name
+	}
+}
+
 func WithAuthorizationHeader() Option {
 	return func(m *middleware) {
 		m.authHeaderEnabled = true

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -8,3 +8,10 @@ func WithAuthCookieName(name string) Option {
 		return nil
 	}
 }
+
+func WithAuthHeaderName(name string) Option {
+	return func(s *Server) error {
+		s.authHeaderName = name
+		return nil
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	router         *mux.Router
 	template       *template.Template
 	authCookieName string
+	authHeaderName string
 }
 
 func New(config *config.Config, cloudfront *cloudfront.Client, opts ...Option) (http.Handler, error) {
@@ -60,7 +61,7 @@ func New(config *config.Config, cloudfront *cloudfront.Client, opts ...Option) (
 	s.router.PathPrefix("/ui/").Handler(http.FileServer(http.FS(embeddedFS)))
 
 	authmiddleware := authorization.New(authorization.WithCookieName(s.authCookieName),
-		authorization.WithAuthorizationHeader())
+		authorization.WithAuthorizationHeader(), authorization.WithHeaderName(s.authHeaderName))
 
 	api := v1beta1.New(s.router,
 		v1beta1_ds.New(config, cloudfront),


### PR DESCRIPTION
* updates go and mods to 1.20 
* removes io/ioutils imports
* updates build images to go 1.20
* fixes a broken test for the authorization middleware
* updates the authorization middleware to prefer named header authentication to cookie authentication when configured
* add support for a named, auth header to the server
* adds the auth-header command line flag